### PR TITLE
Breaks out player update logic

### DIFF
--- a/arduino/health_monitor/health_monitor.ino
+++ b/arduino/health_monitor/health_monitor.ino
@@ -239,7 +239,7 @@ void setup() {
 
     if (!is_monitor_enabled()) {
         Serial.println("Health Monitor disabled");
-        game_reset(g_player_state_persistent);
+        g_player_state_persistent = new_player_state();
     } else {
         // String representing our state (used by other devices to observe us)
         auto const display_state = to_display_state(g_player_state_persistent.health.health);

--- a/arduino/health_monitor/health_monitor.ino
+++ b/arduino/health_monitor/health_monitor.ino
@@ -1,6 +1,23 @@
+// Compile with
+//
+// arduino-cli compile --fqbn esp32:esp32:esp32 src/superspreader/health_monitor/
+//
+
 #include <BLEDevice.h>
 #include <cmath>
-#include <string>
+#include <vector>
+
+#include "health_monitor_core.h"
+
+//// Persistent State ///////////////////////////////////////////////////
+
+RTC_DATA_ATTR PlayerState g_player_state_persistent;
+
+//// Temporary State ////////////////////////////////////////////////////
+
+static bool g_treament_received_interrupt_fired = false;
+
+//// Device stuff ///////////////////////////////////////////////////////
 
 constexpr auto uS_TO_S_FACTOR   = 1000000; /* Conversion factor for micro seconds to seconds */
 constexpr auto TIME_TO_SLEEP    = 5;       /* Time ESP32 will go to sleep (in seconds) */
@@ -21,136 +38,6 @@ constexpr auto red_led_pin   = 17;
 constexpr auto enable_pin    = 18;
 constexpr auto treatment_pin = GPIO_NUM_4;
 
-//// From game_rules_2.py //////////////////////////////////////////
-
-// health is tracked with an unsigned int
-using health_t = unsigned int;
-
-// these are the bounds of the different types of health
-enum struct StateBounds : health_t {
-    IMMUNE            = 1,
-    SUPER_HEALTHY     = 2,
-    HEALTHY           = 10,
-    INFECTED_ASYM     = 40,
-    INFECTED_SYM      = 70,
-    INFECTED_SYM_LATE = 90,
-    ZOMBIE            = 99,
-};
-
-enum struct ProgressRate : health_t {
-    SUPER_HEALTHY = 2,
-    HEALTHY       = 1,
-    INFECTED      = 1,
-};
-
-enum struct InfectionRate : health_t {
-    CAT   = 8,
-    HUMAN = 3,
-};
-
-health_t to_h(StateBounds bounds) { return static_cast<health_t>(bounds); }
-health_t to_h(ProgressRate rate) { return static_cast<health_t>(rate); }
-health_t to_h(InfectionRate rate) { return static_cast<health_t>(rate); }
-
-bool is_immune(health_t health) { return health <= to_h(StateBounds::IMMUNE); }
-bool is_super_healthy(health_t health) {
-    return to_h(StateBounds::SUPER_HEALTHY) <= health && health < to_h(StateBounds::HEALTHY);
-}
-bool is_healthy(health_t health) {
-    return to_h(StateBounds::HEALTHY) <= health && health < to_h(StateBounds::INFECTED_ASYM);
-}
-bool is_infected(health_t health) {
-    return to_h(StateBounds::INFECTED_ASYM) <= health && health < to_h(StateBounds::ZOMBIE);
-}
-bool is_infected_asym(health_t health) {
-    return to_h(StateBounds::INFECTED_ASYM) <= health && health < to_h(StateBounds::INFECTED_SYM);
-}
-bool is_infected_sym(health_t health) {
-    return to_h(StateBounds::INFECTED_SYM) <= health &&
-           health < to_h(StateBounds::INFECTED_SYM_LATE);
-}
-bool is_infected_sym_late(health_t health) {
-    return to_h(StateBounds::INFECTED_SYM_LATE) <= health && health < to_h(StateBounds::ZOMBIE);
-}
-bool is_zombie(health_t health) { return to_h(StateBounds::ZOMBIE) <= health; }
-
-struct HealthState {
-    // using a function resets the value after every boot
-    health_t health     = 2;  // super healthy
-    bool cat_resistance = false;
-};
-
-struct Exposure {
-    health_t human = 0;
-    health_t cat   = 0;
-};
-
-health_t exposure_increase(struct HealthState health_state, struct Exposure exposures) {
-    if (is_immune(health_state.health) || is_infected(health_state.health)) return 0;
-
-    // resistant to cats when cat_resistance = 1
-    return exposures.human * to_h(InfectionRate::HUMAN) +
-           exposures.cat * to_h(InfectionRate::CAT) * (health_state.cat_resistance ? 0 : 1);
-}
-
-// Checks health status, returns a 0 or constant value to increment h by to track disease progress
-health_t time_increase(health_t health) {
-    if (is_super_healthy(health)) {
-        auto const sum       = health + to_h(ProgressRate::SUPER_HEALTHY);
-        auto const remainder = sum % to_h(StateBounds::HEALTHY);
-        auto const quotient  = std::floor(sum / to_h(StateBounds::HEALTHY));
-        return to_h(ProgressRate::SUPER_HEALTHY) - remainder * quotient;
-    }
-    if (is_infected(health)) return to_h(ProgressRate::INFECTED);
-    return 0;
-}
-
-// Checks health status, returns a 0 or constant value to decrement h by to track disease progress
-health_t time_decrease(health_t health) {
-    if (is_healthy(health)) {
-        // Preview the result
-        auto const sum = health - to_h(ProgressRate::HEALTHY);
-        // If the result is too healthy, do nothing
-        return sum > to_h(StateBounds::HEALTHY) ? to_h(ProgressRate::HEALTHY) : 0;
-    }
-    return 0;
-}
-
-// takes current health state (count and cat resistance), count of humans and cats nearby
-HealthState health_update(HealthState health_state, Exposure exposures) {
-    if (is_zombie(health_state.health)) health_state.health = to_h(StateBounds::ZOMBIE);
-    if (is_immune(health_state.health)) health_state.health = to_h(StateBounds::IMMUNE);
-    health_state.health = health_state.health + time_increase(health_state.health) -
-                          time_decrease(health_state.health) +
-                          exposure_increase(health_state, exposures);
-    // Cat resistance is permanent
-    health_state.cat_resistance |= is_infected(health_state.health);
-    if (is_zombie(health_state.health)) health_state.health = to_h(StateBounds::ZOMBIE);
-    return health_state;
-}
-
-HealthState apply_treatment(HealthState health_state) {
-    if (is_infected_sym_late(health_state.health)) {
-        health_state.health = to_h(StateBounds::IMMUNE);
-    } else if (is_infected_sym(health_state.health)) {
-        health_state.health = to_h(StateBounds::HEALTHY);
-    } else if (is_infected_asym(health_state.health)) {
-        health_state.health -= 35;  // sometimes you go healthy, other times super
-    } else if (is_healthy(health_state.health)) {
-        health_state.health = to_h(StateBounds::SUPER_HEALTHY);
-    }
-
-    return health_state;
-}
-
-//// Game State ///////////////////////////////////////////////////
-
-RTC_DATA_ATTR int g_boot_count = 0;
-RTC_DATA_ATTR bool g_treated   = false;
-RTC_DATA_ATTR HealthState g_health_state;
-
-//// Bluetooth ////////////////////////////////////////////////////
-
 bool is_monitor(std::string const& name) { return name.rfind(PREFIX_STR, 0) == 0; }
 
 bool is_close(int rssi) { return rssi >= RSSI_LOWER_BOUND; }
@@ -159,6 +46,7 @@ bool is_infected_human(std::string const& name) {
     auto const state = name.substr(std::string(PREFIX_STR).length());
     return state == A_SYMPTOMATIC_STR || state == SICK_STR || state == ZOMBIE_STR;
 }
+
 bool is_cat(std::string const& name) {
     auto const state = name.substr(std::string(PREFIX_STR).length());
     return state == CAT_STR;
@@ -173,8 +61,8 @@ BLEScanResults scan_ble() {
     return scan->getResults();
 }
 
-Exposure count_exposure(BLEScanResults& results) {
-    Exposure exposure;
+ExposureEvent make_exposure_event_from_scan(BLEScanResults& results) {
+    ExposureEvent exposure;
     exposure.human = 0;
     exposure.cat   = 0;
     for (auto i = 0; i < results.getCount(); ++i) {
@@ -183,8 +71,12 @@ Exposure count_exposure(BLEScanResults& results) {
         auto const name = device.getName();
 
         if (is_monitor(name) && is_close(rssi)) {
-            if (is_infected_human(name)) exposure.human += 1;
-            if (is_cat(name)) exposure.cat += 1;
+            if (is_infected_human(name)) {
+                exposure.human += 1;
+            }
+            if (is_cat(name)) {
+                exposure.cat += 1;
+            }
         }
     }
     return exposure;
@@ -225,7 +117,7 @@ std::string to_display_state(health_t health) {
 }
 
 void IRAM_ATTR receive_treatment() {
-    g_treated = true;
+    g_treament_received_interrupt_fired = true;
     // treatment can only happen once per wakeup
     detachInterrupt(treatment_pin);
 }
@@ -251,19 +143,19 @@ void configure_led_timer(uint64_t period_us) {
     timerAlarmEnable(led_timer);  // Just Enable
 }
 
-void configure_hw() {
+void configure_hw(const struct PlayerState& player) {
     pinMode(enable_pin, INPUT);
     pinMode(green_led_pin, OUTPUT);
     pinMode(red_led_pin, OUTPUT);
     pinMode(treatment_pin, INPUT);
     attachInterrupt(treatment_pin, receive_treatment, RISING);
 
-    if (is_immune(g_health_state.health)) {
+    if (is_immune(player.health.health)) {
         digitalWrite(green_led_pin, HIGH);
-    } else if (is_zombie(g_health_state.health)) {
+    } else if (is_zombie(player.health.health)) {
         digitalWrite(red_led_pin, HIGH);
-    } else if (is_infected(g_health_state.health)) {
-        auto const period = get_blink_period(g_health_state.health);
+    } else if (is_infected(player.health.health)) {
+        auto const period = get_blink_period(player.health.health);
         configure_led_timer(period);
     }
 
@@ -273,36 +165,50 @@ void configure_hw() {
 
 bool is_monitor_enabled() { return !digitalRead(enable_pin); }
 
-void reset_state() {
-    g_boot_count                  = 0;
-    g_health_state.health         = 2;
-    g_health_state.cat_resistance = false;
-}
-
-void print_wakeup_reason() {
+void poll_wakeup_events(std::vector<Event>& event_queue) {
     auto const wakeup_reason = esp_sleep_get_wakeup_cause();
 
     switch (wakeup_reason) {
-        case ESP_SLEEP_WAKEUP_EXT0:
+        case ESP_SLEEP_WAKEUP_EXT0: {
             Serial.println("Wakeup caused by external signal using RTC_IO");
-            g_treated = true;
+            event_queue.emplace_back(TreatmentEvent{});
             break;
-        case ESP_SLEEP_WAKEUP_EXT1:
+        }
+        case ESP_SLEEP_WAKEUP_EXT1: {
             Serial.println("Wakeup caused by external signal using RTC_CNTL");
             break;
-        case ESP_SLEEP_WAKEUP_TIMER:
+        }
+        case ESP_SLEEP_WAKEUP_TIMER: {
             Serial.println("Wakeup caused by timer");
             break;
-        case ESP_SLEEP_WAKEUP_TOUCHPAD:
+        }
+        case ESP_SLEEP_WAKEUP_TOUCHPAD: {
             Serial.println("Wakeup caused by touchpad");
             break;
-        case ESP_SLEEP_WAKEUP_ULP:
+        }
+        case ESP_SLEEP_WAKEUP_ULP: {
             Serial.println("Wakeup caused by ULP program");
             break;
-        default:
+        }
+        default: {
             Serial.printf("Wakeup was not caused by deep sleep: %d\n", wakeup_reason);
             break;
+        }
     }
+}
+
+void poll_bt_events(std::vector<Event>& event_queue) {
+    // Scan for nearby devices and count infected
+    auto devices = scan_ble();
+    print_scan_results(devices);
+
+    // Create exposure data from BT scan results
+    auto const exposure = make_exposure_event_from_scan(devices);
+    Serial.println("Infected human exposure: " + String(exposure.human));
+    Serial.println("Infected cat exposure: " + String(exposure.cat));
+
+    // Add exposure event to queue for this update
+    event_queue.emplace_back(exposure);
 }
 
 void show_treatment_animation() {
@@ -327,54 +233,77 @@ void show_treatment_animation() {
 }
 
 void setup() {
-    configure_hw();
+    configure_hw(g_player_state_persistent);
 
-    Serial.println("Start Health: " + String(g_health_state.health));
+    Serial.println("Start Health: " + String(g_player_state_persistent.health.health));
 
     if (!is_monitor_enabled()) {
         Serial.println("Health Monitor disabled");
-        reset_state();
-    } else if (g_treated) {
-        Serial.println("Treatment received");
-        show_treatment_animation();
-        g_treated = false;
-
-        // apply treatment to the game state
-        g_health_state = apply_treatment(g_health_state);
+        game_reset(g_player_state_persistent);
     } else {
-        print_wakeup_reason();
-        // Increment boot number and print it every reboot
-        ++g_boot_count;
-        Serial.println("Boot number: " + String(g_boot_count));
-
         // String representing our state (used by other devices to observe us)
-        auto const display_state = to_display_state(g_health_state.health);
+        auto const display_state = to_display_state(g_player_state_persistent.health.health);
         Serial.println(display_state.c_str());
-        Serial.println("Health: " + String(g_health_state.health));
-        Serial.println("Cat Resistance: " + String(g_health_state.cat_resistance));
+        Serial.println("Health: " + String(g_player_state_persistent.health.health));
+        Serial.println("Cat Resistance: " +
+                       String(g_player_state_persistent.health.cat_resistance));
 
         // Start bluetooth to advertise our state
         BLEDevice::init(PREFIX_STR + display_state);
         BLEDevice::startAdvertising();
 
-        // Scan for nearby devices and count infected
-        auto devices = scan_ble();
-        print_scan_results(devices);
-        auto const exposure = count_exposure(devices);
-        Serial.println("Infected human exposure: " + String(exposure.human));
-        Serial.println("Infected cat exposure: " + String(exposure.cat));
+        // Event queue will hold semi-dynamic events to process on this tick
+        std::vector<Event> event_queue;
+        event_queue.reserve(3UL);
 
-        // Update our health value
-        g_health_state = health_update(g_health_state, exposure);
+        // Get any events caused by device wakeup events
+        poll_wakeup_events(event_queue);
+
+        // Get any events from BT scan
+        poll_bt_events(event_queue);
+
+        // Run game update for all enqueued events
+        game_update(
+            g_player_state_persistent,
+            // get next event
+            [&event_queue]() -> Event {
+                if (g_treament_received_interrupt_fired) {
+                    event_queue.emplace_back(TreatmentEvent{});
+                    g_treament_received_interrupt_fired = false;
+                }
+
+                Event next_event;  // null state
+                if (!event_queue.empty()) {
+                    next_event = event_queue.back();
+                    event_queue.pop_back();
+                }
+
+                return next_event;
+            },
+            // on exposure
+            [](ExposureEvent const& exposure) {
+                (void)exposure;
+                Serial.println("Player exposed to virus");
+            },
+            // on treatment
+            [](TreatmentEvent const& treatment) {
+                (void)treatment;
+                Serial.println("Player administered treatment");
+
+                // Do some beep boops
+                show_treatment_animation();
+            });
     }
+
     // Flush the serial buffer
     Serial.flush();
 
-    Serial.println("End Health: " + String(g_health_state.health));
+    Serial.println("End Health: " + String(g_player_state_persistent.health.health));
 
     // Enable waking up in some amount of time and sleep
     // Tests confirm that random does not produce the same number after reset
     esp_sleep_enable_timer_wakeup(random(1, TIME_TO_SLEEP) * uS_TO_S_FACTOR);
+
     // Wakeup when treatment pin goes high
     esp_sleep_enable_ext0_wakeup(treatment_pin, 1);
     esp_deep_sleep_start();

--- a/arduino/health_monitor/health_monitor_core.cpp
+++ b/arduino/health_monitor/health_monitor_core.cpp
@@ -1,0 +1,77 @@
+// Originally from game_rules_2.py
+
+// Game
+#include "health_monitor_core.h"
+
+namespace {
+
+health_t exposure_increase(HealthState const health_state, ExposureEvent const exposures) {
+    if (is_immune(health_state.health) || is_infected(health_state.health)) return 0;
+
+    // resistant to cats when cat_resistance = 1
+    return exposures.human * to_health(InfectionRate::HUMAN) +
+           exposures.cat * to_health(InfectionRate::CAT) * (health_state.cat_resistance ? 0 : 1);
+}
+
+// Checks health status, returns a 0 or constant value to increment h by to track disease progress
+health_t time_increase(health_t health) {
+    if (is_super_healthy(health)) {
+        auto const sum       = health + to_health(ProgressRate::SUPER_HEALTHY);
+        auto const remainder = sum % to_health(StateBounds::HEALTHY);
+        auto const quotient  = std::floor(sum / to_health(StateBounds::HEALTHY));
+        return to_health(ProgressRate::SUPER_HEALTHY) - remainder * quotient;
+    }
+    if (is_infected(health)) return to_health(ProgressRate::INFECTED);
+    return 0;
+}
+
+// Checks health status, returns a 0 or constant value to decrement h by to track disease progress
+health_t time_decrease(health_t health) {
+    if (is_healthy(health)) {
+        // Preview the result
+        auto const sum = health - to_health(ProgressRate::HEALTHY);
+        // If the result is too healthy, do nothing
+        return sum > to_health(StateBounds::HEALTHY) ? to_health(ProgressRate::HEALTHY) : 0;
+    }
+    return 0;
+}
+
+}  // namespace
+
+HealthState exposure_update(HealthState health_state, ExposureEvent const exposures) {
+    if (is_zombie(health_state.health)) {
+        health_state.health = to_health(StateBounds::ZOMBIE);
+    }
+    if (is_immune(health_state.health)) {
+        health_state.health = to_health(StateBounds::IMMUNE);
+    }
+    health_state.health = health_state.health + time_increase(health_state.health) -
+                          time_decrease(health_state.health) +
+                          exposure_increase(health_state, exposures);
+    // Cat resistance is permanent
+    health_state.cat_resistance |= is_infected(health_state.health);
+    if (is_zombie(health_state.health)) {
+        health_state.health = to_health(StateBounds::ZOMBIE);
+    }
+    return health_state;
+}
+
+HealthState treament_update(HealthState health_state) {
+    if (is_infected_sym_late(health_state.health)) {
+        health_state.health = to_health(StateBounds::IMMUNE);
+    } else if (is_infected_sym(health_state.health)) {
+        health_state.health = to_health(StateBounds::HEALTHY);
+    } else if (is_infected_asym(health_state.health)) {
+        health_state.health -= 35;  // sometimes you go healthy, other times super
+    } else if (is_healthy(health_state.health)) {
+        health_state.health = to_health(StateBounds::SUPER_HEALTHY);
+    }
+
+    return health_state;
+}
+
+void game_reset(struct PlayerState& player) {
+    player.tick                  = 0;
+    player.health.health         = 2;
+    player.health.cat_resistance = false;
+}

--- a/arduino/health_monitor/health_monitor_core.cpp
+++ b/arduino/health_monitor/health_monitor_core.cpp
@@ -70,8 +70,10 @@ HealthState treament_update(HealthState health_state) {
     return health_state;
 }
 
-void game_reset(struct PlayerState& player) {
+PlayerState new_player_state() {
+    PlayerState player;
     player.tick                  = 0;
     player.health.health         = 2;
     player.health.cat_resistance = false;
+    return player;
 }

--- a/arduino/health_monitor/health_monitor_core.h
+++ b/arduino/health_monitor/health_monitor_core.h
@@ -139,7 +139,7 @@ HealthState exposure_update(HealthState health_state, ExposureEvent const exposu
 // updates health according to treatment rules
 HealthState treament_update(HealthState health_state);
 
-void game_reset(struct PlayerState& player);
+PlayerState new_player_state();
 
 template <typename GetNextEventT, typename OnExposureT, typename OnTreatmentT>
 void game_update(struct PlayerState& player,

--- a/arduino/health_monitor/health_monitor_core.h
+++ b/arduino/health_monitor/health_monitor_core.h
@@ -1,0 +1,194 @@
+// Defines core player update logic for health monitor device
+
+#ifndef HEALTH_MONITOR_CORE_H
+#define HEALTH_MONITOR_CORE_H
+
+// C++ Standard Library
+#include <cmath>
+#include <type_traits>
+#include <utility>
+
+// health is tracked with an unsigned int
+using health_t = unsigned int;
+
+// these are the bounds of the different types of health
+enum struct StateBounds : health_t {
+    IMMUNE            = 1,
+    SUPER_HEALTHY     = 2,
+    HEALTHY           = 10,
+    INFECTED_ASYM     = 40,
+    INFECTED_SYM      = 70,
+    INFECTED_SYM_LATE = 90,
+    ZOMBIE            = 99,
+};
+
+enum struct ProgressRate : health_t {
+    SUPER_HEALTHY = 2,
+    HEALTHY       = 1,
+    INFECTED      = 1,
+};
+
+enum struct InfectionRate : health_t {
+    CAT   = 8,
+    HUMAN = 3,
+};
+
+template <typename T>
+constexpr health_t to_health(T bounds) {
+    static_assert(std::is_same<typename std::underlying_type<T>::type, health_t>());
+    return static_cast<health_t>(bounds);
+}
+
+constexpr bool is_immune(health_t health) { return health <= to_health(StateBounds::IMMUNE); }
+
+constexpr bool is_super_healthy(health_t health) {
+    return to_health(StateBounds::SUPER_HEALTHY) <= health &&
+           health < to_health(StateBounds::HEALTHY);
+}
+
+constexpr bool is_healthy(health_t health) {
+    return to_health(StateBounds::HEALTHY) <= health &&
+           health < to_health(StateBounds::INFECTED_ASYM);
+}
+
+constexpr bool is_infected(health_t health) {
+    return to_health(StateBounds::INFECTED_ASYM) <= health &&
+           health < to_health(StateBounds::ZOMBIE);
+}
+
+constexpr bool is_infected_asym(health_t health) {
+    return to_health(StateBounds::INFECTED_ASYM) <= health &&
+           health < to_health(StateBounds::INFECTED_SYM);
+}
+
+constexpr bool is_infected_sym(health_t health) {
+    return to_health(StateBounds::INFECTED_SYM) <= health &&
+           health < to_health(StateBounds::INFECTED_SYM_LATE);
+}
+
+constexpr bool is_infected_sym_late(health_t health) {
+    return to_health(StateBounds::INFECTED_SYM_LATE) <= health &&
+           health < to_health(StateBounds::ZOMBIE);
+}
+
+constexpr bool is_zombie(health_t health) { return to_health(StateBounds::ZOMBIE) <= health; }
+
+struct HealthState {
+    // using a function resets the value after every boot
+    health_t health     = 2;  // super healthy
+    bool cat_resistance = false;
+};
+
+struct PlayerState {
+    /// Current game tick
+    int tick = 0;
+
+    /// Current player health
+    HealthState health;
+};
+
+struct ExposureEvent {
+    health_t human = 0;
+    health_t cat   = 0;
+};
+
+struct TreatmentEvent {};
+
+struct Event {
+    enum class Type {
+        NIL       = 0,
+        EXPOSURE  = 1,
+        TREATMENT = 2,
+    };
+
+    Type type;
+
+    union EventData {
+        ExposureEvent exposure;
+        TreatmentEvent treatment;
+    };
+
+    EventData data;
+
+    Event() : type{Type::NIL}, data{} {}
+    explicit Event(ExposureEvent _data) : type{Type::EXPOSURE}, data{.exposure = _data} {}
+    explicit Event(TreatmentEvent _data) : type{Type::TREATMENT}, data{.treatment = _data} {}
+
+    constexpr bool is_valid() const { return type != Type::NIL; }
+};
+
+template <typename ExposureEventHandler, typename TreatmentEventHandler>
+void visit(Event const& event,
+           ExposureEventHandler exposure_handler,
+           TreatmentEventHandler treatment_handler) {
+    switch (event.type) {
+        case Event::Type::NIL:
+            break;
+        case Event::Type::EXPOSURE:
+            exposure_handler(event.data.exposure);
+            break;
+        case Event::Type::TREATMENT:
+            treatment_handler(event.data.treatment);
+            break;
+    }
+}
+
+// takes current health state (count and cat resistance), count of humans and cats nearby
+HealthState exposure_update(HealthState health_state, ExposureEvent const exposures);
+
+// updates health according to treatment rules
+HealthState treament_update(HealthState health_state);
+
+void game_reset(struct PlayerState& player);
+
+template <typename GetNextEventT, typename OnExposureT, typename OnTreatmentT>
+void game_update(struct PlayerState& player,
+                 GetNextEventT get_next_event,
+                 OnExposureT on_exposure,
+                 OnTreatmentT on_treatment) {
+    // Tick time alive
+    ++player.tick;
+
+    // Latching treatment flag
+    bool treatment_previously_received = false;
+
+    // Handle all events
+    while (true) {
+        // Get next enqueue event
+        auto const event = get_next_event();
+
+        // If there are no more events, stop processing
+        if (!event.is_valid()) {
+            return;
+        }
+
+        // Run core game event logic
+        visit(
+            event,
+            [&on_exposure, &player](ExposureEvent const& exposure) {
+                // Do normal player health update
+                player.health = exposure_update(player.health, exposure);
+
+                // Call any context-specific callbacks
+                on_exposure(exposure);
+            },
+            [&on_treatment, &player, &treatment_previously_received](
+                TreatmentEvent const& treatment) {
+                // Skip if player has already been treated on this tick
+                if (treatment_previously_received) {
+                    return;
+                }
+
+                // Apply treatment modifier to player health
+                player.health = treament_update(player.health);
+
+                // Set latching flag to indicate treatment already happened on this tick
+                treatment_previously_received = true;
+
+                // Call any context-specific callbacks
+                on_treatment(treatment);
+            });
+    }
+}
+
+#endif  // HEALTH_MONITOR_CORE_H


### PR DESCRIPTION

## Description

- cut out player update stuff from any hardware entanglement
- makes player updates "event based" to abstract away hardware events like interupts or wakeup-type-specific behaviors
- adds abstract `game_update` event handler function which can be customized per target device
- updates `health_monitor.ino` to use the new stuff

## Testing

Compiled it?

## Notes


